### PR TITLE
Add /api/health endpoint

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+import pkg from "../../../../package.json";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
+    version: process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || pkg.version,
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a trivial `GET /api/health` route returning `{status: "ok", version}` (version = Vercel commit SHA when deployed, falling back to package.json's version locally).

## Test plan
- This repo has no test command (`package.json` scripts are only `dev`/`build`/`start`/`lint` - no test runner configured). Noting per COO repo rules since no test suite exists to run.
- `npx tsc --noEmit` passes clean.
- `npm run lint` has 6 pre-existing errors / 1 warning, all unrelated to this change (unescaped apostrophes in contact/not-found pages, a missing alt prop on opengraph-image) - none in the new file.

First Tier 1 task from the COO project-tracking setup (see projects/bougieadventure.md in the coo repo) - resolves the "no health-check URL" gap.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>