### PR TITLE
Fix newsletter signup form and escape user input in emails

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { escapeHtml } from '@/lib/escapeHtml';
 
 export async function POST(request: Request) {
   try {
@@ -15,15 +16,22 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
     }
 
+    const safeName = escapeHtml(name);
+    const safeEmail = escapeHtml(email);
+    const safePhone = phone ? escapeHtml(phone) : '';
+    const safeTrip = trip ? escapeHtml(trip) : '';
+    const safeGroupSize = groupSize ? escapeHtml(groupSize) : '';
+    const safeMessage = escapeHtml(message).replace(/\n/g, '<br>');
+
     const html = `
-      <h2>New inquiry from ${name}</h2>
-      <p><strong>Name:</strong> ${name}</p>
-      <p><strong>Email:</strong> ${email}</p>
-      ${phone ? `<p><strong>Phone:</strong> ${phone}</p>` : ''}
-      ${trip ? `<p><strong>Trip interest:</strong> ${trip}</p>` : ''}
-      ${groupSize ? `<p><strong>Group size:</strong> ${groupSize}</p>` : ''}
+      <h2>New inquiry from ${safeName}</h2>
+      <p><strong>Name:</strong> ${safeName}</p>
+      <p><strong>Email:</strong> ${safeEmail}</p>
+      ${safePhone ? `<p><strong>Phone:</strong> ${safePhone}</p>` : ''}
+      ${safeTrip ? `<p><strong>Trip interest:</strong> ${safeTrip}</p>` : ''}
+      ${safeGroupSize ? `<p><strong>Group size:</strong> ${safeGroupSize}</p>` : ''}
       <p><strong>Message:</strong></p>
-      <p>${message.replace(/\n/g, '<br>')}</p>
+      <p>${safeMessage}</p>
     `;
 
     const res = await fetch('https://api.resend.com/emails', {

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { escapeHtml } from '@/lib/escapeHtml';
 
 // Adds the subscriber to the Emma (Email+) audience. Returns false on any
 // failure so the Resend notification below still captures the lead.
@@ -56,10 +57,13 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
     }
 
+    const safeName = name ? escapeHtml(name) : '';
+    const safeEmail = escapeHtml(email);
+
     const html = `
       <h2>New Bougie email signup</h2>
-      ${name ? `<p><strong>Name:</strong> ${name}</p>` : ''}
-      <p><strong>Email:</strong> ${email}</p>
+      ${safeName ? `<p><strong>Name:</strong> ${safeName}</p>` : ''}
+      <p><strong>Email:</strong> ${safeEmail}</p>
       ${addedToEmma
         ? '<p>Already added to your Email+ audience automatically. No action needed.</p>'
         : '<p>Could not add this contact to Email+ automatically. Add them manually.</p>'}

--- a/src/app/blog/NewsletterForm.tsx
+++ b/src/app/blog/NewsletterForm.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
+
+type Status = 'idle' | 'loading' | 'success' | 'error';
+
+export default function NewsletterForm() {
+  const [status, setStatus] = useState<Status>('idle');
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setStatus('loading');
+    const form = e.currentTarget;
+    const data = Object.fromEntries(new FormData(form));
+
+    try {
+      const res = await fetch('/api/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) throw new Error();
+      setStatus('success');
+      form.reset();
+    } catch {
+      setStatus('error');
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <p className="font-serif text-lg font-semibold text-royal-blue max-w-md mx-auto">
+        You&apos;re in! Welcome to the Bougies.
+      </p>
+    );
+  }
+
+  return (
+    <div className="max-w-md mx-auto space-y-2">
+      <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-3">
+        <input
+          name="email"
+          type="email"
+          required
+          placeholder="your@email.com"
+          className="flex-1 px-5 py-3 rounded-full border border-gold/30 text-sm focus:outline-none focus:border-gold bg-white"
+        />
+        <button
+          type="submit"
+          disabled={status === 'loading'}
+          className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-full bg-gold text-royal-blue-dark text-sm font-semibold hover:bg-gold-light transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {status === 'loading' ? (
+            <><Loader2 size={16} className="animate-spin" /> Joining…</>
+          ) : (
+            'Subscribe'
+          )}
+        </button>
+      </form>
+      {status === 'error' && (
+        <p className="text-red-600 text-xs">Something went wrong. Please try again.</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
 import { posts, tripSeries } from './posts';
+import NewsletterForm from './NewsletterForm';
 
 export const metadata: Metadata = {
   title: 'Journal',
@@ -73,19 +74,7 @@ export default function BlogPage() {
         <div className="max-w-xl mx-auto space-y-4">
           <h2 className="font-serif text-3xl font-semibold text-royal-blue">Get Trip Stories in Your Inbox</h2>
           <p className="text-charcoal/75 text-sm">Recaps, early trip announcements, and packing guides. No spam, ever.</p>
-          <form className="flex flex-col sm:flex-row gap-3 max-w-md mx-auto">
-            <input
-              type="email"
-              placeholder="your@email.com"
-              className="flex-1 px-5 py-3 rounded-full border border-gold/30 text-sm focus:outline-none focus:border-gold bg-white"
-            />
-            <button
-              type="submit"
-              className="px-6 py-3 rounded-full bg-gold text-royal-blue-dark text-sm font-semibold hover:bg-gold-light transition-colors"
-            >
-              Subscribe
-            </button>
-          </form>
+          <NewsletterForm />
         </div>
       </section>
     </>

--- a/src/lib/escapeHtml.ts
+++ b/src/lib/escapeHtml.ts
@@ -1,0 +1,12 @@
+// Escapes user-supplied text before it is interpolated into an HTML string.
+// Used by the contact/subscribe API routes, which splice form fields into
+// email bodies sent via Resend — without this, a submitted `<script>` or
+// styled fake link would render as live HTML in the recipient's inbox.
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}


### PR DESCRIPTION
## Summary

Fixes two issues:

**#13 — newsletter signup form on `/blog` silently fails (no data sent)**
The "Get Trip Stories in Your Inbox" form had no `onSubmit`/`action`/`method`, so submitting it triggered a native browser GET reload of the current page with the email appended as a URL query param — nothing was ever sent to `/api/subscribe`. Extracted the form into `src/app/blog/NewsletterForm.tsx`, a client component that `fetch()`s `/api/subscribe` with loading/success/error states, mirroring the existing pattern in `EmailCapturePopup.tsx` (and `ContactForm.tsx`).

**#14 — unescaped user input in contact/subscribe emails (HTML-injection vector)**
`api/contact/route.ts` and `api/subscribe/route.ts` spliced `name`, `email`, `phone`, `trip`, `groupSize`, and `message` directly into an HTML email body sent via Resend to Laurel/Nicole's inboxes, with only newline-to-`<br>` conversion and no escaping. A submitter could inject arbitrary HTML (e.g. a spoofed "click here" link) that would render live in the recipient's email client. Added `src/lib/escapeHtml.ts` (no suitable existing utility or dependency found in this codebase) and applied it to every user-supplied field before interpolation, in both routes.

## Verification

- `npm run build` — succeeds
- `npm run lint` — no new errors; the 6 pre-existing `react/no-unescaped-entities` errors (ContactForm.tsx, contact/page.tsx, not-found.tsx, Footer.tsx) and 1 pre-existing `alt-text` warning (opengraph-image.tsx) are all in files this PR does not touch
- No test framework configured in this repo (not added one for this fix)

## Governance note

**Not merging automatically** — per this project's standing rule, changes here need Laurel/Nicole (or the owner acting on their behalf) to sign off before merging. Ready for review.

Fixes #13, #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PXbCLyWTELUypsyZR1e7z